### PR TITLE
Update run.sh

### DIFF
--- a/image/run.sh
+++ b/image/run.sh
@@ -15,4 +15,7 @@ fi
 dbus-daemon --system
 avahi-daemon -D
 
+service dbus start
+service avahi-daemon start
+
 homebridge


### PR DESCRIPTION
Modified to avoid the dns service error when a container is restarted. Without the dbus and avahi start commands I would get the error below if the container wasn't deleted from docker.

Error: dns service error: unknown
at Error (native)
at new Advertisement (/usr/local/lib/node_modules/homebridge/node_modules/ha p-nodejs/node_modules/mdns/lib/advertisement.js:56:10)